### PR TITLE
Feature/refine frontend design

### DIFF
--- a/backend/api/routes/audio.py
+++ b/backend/api/routes/audio.py
@@ -115,8 +115,13 @@ async def translate_audio(
             detail=f"File too large. Maximum size is {MAX_FILE_SIZE // (1024 * 1024)}MB"
         )
     
-    # Get settings and create OpenAI client
+    # Get settings and create OpenAI client (Whisper requires OpenAI API)
     settings = get_settings()
+    if not (settings.openai_api_key or "").strip():
+        raise HTTPException(
+            status_code=503,
+            detail="Speech-to-text requires OPENAI_API_KEY. Set it in .env or use llm_provider=openai.",
+        )
     client = OpenAI(api_key=settings.openai_api_key)
     
     # Create temporary file with proper cleanup (Windows-compatible)

--- a/backend/api/routes/moat.py
+++ b/backend/api/routes/moat.py
@@ -1,67 +1,66 @@
 """
 Overall moat score endpoint for full 2015-2025 analysis.
+
+The moat rating is defined only for the fixed period 2015-01-01 to 2025-12-31.
+Query params start_date/end_date are ignored; the response always reflects
+and displays this analysis period.
+
+This endpoint now uses REAL data-driven analysis instead of mock scores.
 """
 
 from fastapi import APIRouter, HTTPException, Query
 from datetime import datetime
-from typing import Optional
 import hashlib
-import json
+import logging
+
+from services.data_driven_moat_scorer import DataDrivenMoatScorer
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/moat", tags=["moat"])
+
+# Fixed analysis period for overall moat rating (not user-configurable)
+MOAT_START = "2015-01-01"
+MOAT_END = "2025-12-31"
 
 # In-memory cache for computed scores (in production, use Redis or similar)
 _moat_cache: dict = {}
 
+# Global scorer instance (reused across requests)
+_moat_scorer = DataDrivenMoatScorer()
 
-def generate_cache_key(ticker: str, start_date: str, end_date: str) -> str:
-    """Generate a cache key for moat score lookup."""
-    key_str = f"{ticker}_{start_date}_{end_date}"
-    return hashlib.md5(key_str.encode()).hexdigest()
+
+def _cache_key(ticker: str) -> str:
+    """Cache key is ticker-only; period is always 2015-2025."""
+    return hashlib.md5(f"{ticker}_{MOAT_START}_{MOAT_END}".encode()).hexdigest()
 
 
 @router.get("/overall")
 async def get_overall_moat_score(
     ticker: str = Query(..., description="Stock ticker symbol"),
-    start_date: Optional[str] = Query(None, description="Start date (YYYY-MM-DD)"),
-    end_date: Optional[str] = Query(None, description="End date (YYYY-MM-DD)"),
 ):
     """
-    Get overall moat score for a ticker across specified date range.
-    
-    If dates match 2015-01-01 to 2025-12-31, returns cached full analysis.
-    Otherwise, computes analysis on-demand.
-    
+    Get overall moat score for a ticker.
+
+    The rating is always computed for the fixed analysis period 2015-01-01
+    to 2025-12-31. The response field time_range always reflects this period.
+    Any start_date/end_date query params are ignored.
+
     Returns:
-        OverallMoatScore with comprehensive moat analysis
+        OverallMoatScore with comprehensive moat analysis and time_range 2015-2025.
     """
     try:
-        # Default to full range if not specified
-        start = start_date or "2015-01-01"
-        end = end_date or "2025-12-31"
-        
-        # Check if this is the full range (can use cached data)
-        is_full_range = start == "2015-01-01" and end == "2025-12-31"
-        
-        # Generate cache key
-        cache_key = generate_cache_key(ticker.upper(), start, end)
-        
-        # Check cache first
-        if cache_key in _moat_cache:
-            cached_result = _moat_cache[cache_key]
-            # Add metadata about cache hit
-            cached_result["from_cache"] = True
-            return cached_result
-        
-        # Mock computation (in production, this would call actual analysis)
-        # For now, return mock data based on ticker
-        moat_score = _compute_moat_score(ticker.upper(), start, end, is_full_range)
-        
-        # Cache the result
-        _moat_cache[cache_key] = moat_score
-        
+        key = _cache_key(ticker.upper())
+
+        if key in _moat_cache:
+            out = _moat_cache[key]
+            out["from_cache"] = True
+            return out
+
+        moat_score = _compute_moat_score(ticker.upper())
+        _moat_cache[key] = moat_score
         return moat_score
-        
+
     except Exception as e:
         raise HTTPException(
             status_code=500,
@@ -69,110 +68,57 @@ async def get_overall_moat_score(
         )
 
 
-def _compute_moat_score(ticker: str, start_date: str, end_date: str, is_full_range: bool) -> dict:
+def _compute_moat_score(ticker: str) -> dict:
     """
-    Compute overall moat score for a ticker.
+    Compute overall moat score for a ticker over the fixed period 2015-2025.
+
+    Uses real data-driven analysis:
+    1. Loads historical price data from yfinance (2015-2025)
+    2. Analyzes news coverage from FNSPID dataset
+    3. Calculates quantitative metrics for each moat factor
+    4. Scores based on financial performance and stability
     
-    This is a mock implementation. In production, this would:
-    1. Analyze historical data
-    2. Process news events
-    3. Evaluate competitive dynamics
-    4. Score each moat factor
+    Args:
+        ticker: Stock ticker symbol
+        
+    Returns:
+        Dict with overall_score, rating, confidence, factors, trend, summary
     """
+    logger.info(f"Computing data-driven moat score for {ticker}")
     
-    # Mock scores based on ticker (replace with real analysis)
-    mock_scores = {
-        "NVDA": {
-            "overall_score": 4.5,
-            "rating": "Wide",
-            "confidence": "High",
-            "factors": {
-                "network_effects": 4.2,
-                "switching_costs": 4.5,
-                "intangible_assets": 4.8,
-                "cost_advantages": 4.3,
-                "regulatory_barriers": 4.6,
-            },
-            "trend": "strengthening",
-            "summary": "NVIDIA demonstrates a wide moat driven by strong intangible assets (CUDA ecosystem, brand), high switching costs (software lock-in), and significant network effects. The company's position in AI accelerators has strengthened substantially from 2015-2025."
-        },
-        "AAPL": {
-            "overall_score": 4.8,
-            "rating": "Wide",
-            "confidence": "High",
-            "factors": {
-                "network_effects": 4.9,
-                "switching_costs": 4.8,
-                "intangible_assets": 4.9,
-                "cost_advantages": 4.5,
-                "regulatory_barriers": 4.3,
-            },
-            "trend": "stable",
-            "summary": "Apple exhibits an exceptionally wide moat characterized by powerful network effects (ecosystem), extremely high switching costs, and strong brand intangibles. The ecosystem moat has remained consistently strong throughout 2015-2025."
-        },
-        "MSFT": {
-            "overall_score": 4.6,
-            "rating": "Wide",
-            "confidence": "High",
-            "factors": {
-                "network_effects": 4.7,
-                "switching_costs": 4.8,
-                "intangible_assets": 4.5,
-                "cost_advantages": 4.4,
-                "regulatory_barriers": 4.4,
-            },
-            "trend": "strengthening",
-            "summary": "Microsoft's moat has strengthened significantly through its cloud transition. Extremely high switching costs in enterprise software, growing network effects in Teams/Azure, and strong recurring revenue models create a formidable competitive advantage."
-        },
-        "AMD": {
-            "overall_score": 3.4,
+    try:
+        # Use the data-driven scorer
+        score_data = _moat_scorer.calculate_moat_score(
+            ticker=ticker,
+            start_date=MOAT_START,
+            end_date=MOAT_END
+        )
+        
+        logger.info(
+            f"Computed moat score for {ticker}: "
+            f"{score_data['overall_score']:.2f} ({score_data['rating']}) "
+            f"confidence={score_data['confidence']}"
+        )
+        
+        return score_data
+        
+    except Exception as e:
+        logger.error(f"Error computing moat score for {ticker}: {e}", exc_info=True)
+        # Return default score on error
+        return {
+            "overall_score": 3.0,
             "rating": "Narrow",
-            "confidence": "Medium",
+            "confidence": "Low",
             "factors": {
-                "network_effects": 3.2,
+                "network_effects": 3.0,
                 "switching_costs": 3.0,
-                "intangible_assets": 4.0,
-                "cost_advantages": 3.4,
-                "regulatory_barriers": 2.9,
-            },
-            "trend": "strengthening",
-            "summary": "AMD has a narrow but improving moat. Strong technical capabilities and IP provide intangible asset advantages, but faces intense competition from Intel and NVIDIA. Switching costs are moderate as customers can migrate between x86 architectures."
-        },
-        "GOOGL": {
-            "overall_score": 4.9,
-            "rating": "Wide",
-            "confidence": "High",
-            "factors": {
-                "network_effects": 4.9,
-                "switching_costs": 4.6,
-                "intangible_assets": 4.8,
-                "cost_advantages": 4.8,
-                "regulatory_barriers": 4.1,
+                "intangible_assets": 3.0,
+                "cost_advantages": 3.0,
+                "regulatory_barriers": 3.0,
             },
             "trend": "stable",
-            "summary": "Google possesses one of the widest moats in technology, driven by unparalleled network effects in search/advertising, massive scale advantages, and dominant brand equity. Despite regulatory challenges, the core search moat remains intact."
-        },
-    }
-    
-    # Get ticker-specific scores or use defaults
-    score_data = mock_scores.get(ticker, {
-        "overall_score": 3.0,
-        "rating": "Narrow",
-        "confidence": "Medium",
-        "factors": {
-            "network_effects": 3.0,
-            "switching_costs": 3.0,
-            "intangible_assets": 3.0,
-            "cost_advantages": 3.0,
-            "regulatory_barriers": 3.0,
-        },
-        "trend": "stable",
-        "summary": f"{ticker} exhibits moderate competitive advantages with room for strengthening across multiple moat factors."
-    })
-    
-    return {
-        **score_data,
-        "time_range": f"{start_date} to {end_date}",
-        "computed_at": datetime.utcnow().isoformat(),
-        "from_cache": False,
-    }
+            "summary": f"Unable to compute moat score for {ticker} due to data availability issues. Using default neutral values.",
+            "time_range": f"{MOAT_START} to {MOAT_END}",
+            "computed_at": datetime.utcnow().isoformat(),
+            "from_cache": False,
+        }

--- a/backend/api/routes/moat.py
+++ b/backend/api/routes/moat.py
@@ -1,0 +1,178 @@
+"""
+Overall moat score endpoint for full 2015-2025 analysis.
+"""
+
+from fastapi import APIRouter, HTTPException, Query
+from datetime import datetime
+from typing import Optional
+import hashlib
+import json
+
+router = APIRouter(prefix="/api/v1/moat", tags=["moat"])
+
+# In-memory cache for computed scores (in production, use Redis or similar)
+_moat_cache: dict = {}
+
+
+def generate_cache_key(ticker: str, start_date: str, end_date: str) -> str:
+    """Generate a cache key for moat score lookup."""
+    key_str = f"{ticker}_{start_date}_{end_date}"
+    return hashlib.md5(key_str.encode()).hexdigest()
+
+
+@router.get("/overall")
+async def get_overall_moat_score(
+    ticker: str = Query(..., description="Stock ticker symbol"),
+    start_date: Optional[str] = Query(None, description="Start date (YYYY-MM-DD)"),
+    end_date: Optional[str] = Query(None, description="End date (YYYY-MM-DD)"),
+):
+    """
+    Get overall moat score for a ticker across specified date range.
+    
+    If dates match 2015-01-01 to 2025-12-31, returns cached full analysis.
+    Otherwise, computes analysis on-demand.
+    
+    Returns:
+        OverallMoatScore with comprehensive moat analysis
+    """
+    try:
+        # Default to full range if not specified
+        start = start_date or "2015-01-01"
+        end = end_date or "2025-12-31"
+        
+        # Check if this is the full range (can use cached data)
+        is_full_range = start == "2015-01-01" and end == "2025-12-31"
+        
+        # Generate cache key
+        cache_key = generate_cache_key(ticker.upper(), start, end)
+        
+        # Check cache first
+        if cache_key in _moat_cache:
+            cached_result = _moat_cache[cache_key]
+            # Add metadata about cache hit
+            cached_result["from_cache"] = True
+            return cached_result
+        
+        # Mock computation (in production, this would call actual analysis)
+        # For now, return mock data based on ticker
+        moat_score = _compute_moat_score(ticker.upper(), start, end, is_full_range)
+        
+        # Cache the result
+        _moat_cache[cache_key] = moat_score
+        
+        return moat_score
+        
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to compute moat score: {str(e)}"
+        )
+
+
+def _compute_moat_score(ticker: str, start_date: str, end_date: str, is_full_range: bool) -> dict:
+    """
+    Compute overall moat score for a ticker.
+    
+    This is a mock implementation. In production, this would:
+    1. Analyze historical data
+    2. Process news events
+    3. Evaluate competitive dynamics
+    4. Score each moat factor
+    """
+    
+    # Mock scores based on ticker (replace with real analysis)
+    mock_scores = {
+        "NVDA": {
+            "overall_score": 4.5,
+            "rating": "Wide",
+            "confidence": "High",
+            "factors": {
+                "network_effects": 4.2,
+                "switching_costs": 4.5,
+                "intangible_assets": 4.8,
+                "cost_advantages": 4.3,
+                "regulatory_barriers": 4.6,
+            },
+            "trend": "strengthening",
+            "summary": "NVIDIA demonstrates a wide moat driven by strong intangible assets (CUDA ecosystem, brand), high switching costs (software lock-in), and significant network effects. The company's position in AI accelerators has strengthened substantially from 2015-2025."
+        },
+        "AAPL": {
+            "overall_score": 4.8,
+            "rating": "Wide",
+            "confidence": "High",
+            "factors": {
+                "network_effects": 4.9,
+                "switching_costs": 4.8,
+                "intangible_assets": 4.9,
+                "cost_advantages": 4.5,
+                "regulatory_barriers": 4.3,
+            },
+            "trend": "stable",
+            "summary": "Apple exhibits an exceptionally wide moat characterized by powerful network effects (ecosystem), extremely high switching costs, and strong brand intangibles. The ecosystem moat has remained consistently strong throughout 2015-2025."
+        },
+        "MSFT": {
+            "overall_score": 4.6,
+            "rating": "Wide",
+            "confidence": "High",
+            "factors": {
+                "network_effects": 4.7,
+                "switching_costs": 4.8,
+                "intangible_assets": 4.5,
+                "cost_advantages": 4.4,
+                "regulatory_barriers": 4.4,
+            },
+            "trend": "strengthening",
+            "summary": "Microsoft's moat has strengthened significantly through its cloud transition. Extremely high switching costs in enterprise software, growing network effects in Teams/Azure, and strong recurring revenue models create a formidable competitive advantage."
+        },
+        "AMD": {
+            "overall_score": 3.4,
+            "rating": "Narrow",
+            "confidence": "Medium",
+            "factors": {
+                "network_effects": 3.2,
+                "switching_costs": 3.0,
+                "intangible_assets": 4.0,
+                "cost_advantages": 3.4,
+                "regulatory_barriers": 2.9,
+            },
+            "trend": "strengthening",
+            "summary": "AMD has a narrow but improving moat. Strong technical capabilities and IP provide intangible asset advantages, but faces intense competition from Intel and NVIDIA. Switching costs are moderate as customers can migrate between x86 architectures."
+        },
+        "GOOGL": {
+            "overall_score": 4.9,
+            "rating": "Wide",
+            "confidence": "High",
+            "factors": {
+                "network_effects": 4.9,
+                "switching_costs": 4.6,
+                "intangible_assets": 4.8,
+                "cost_advantages": 4.8,
+                "regulatory_barriers": 4.1,
+            },
+            "trend": "stable",
+            "summary": "Google possesses one of the widest moats in technology, driven by unparalleled network effects in search/advertising, massive scale advantages, and dominant brand equity. Despite regulatory challenges, the core search moat remains intact."
+        },
+    }
+    
+    # Get ticker-specific scores or use defaults
+    score_data = mock_scores.get(ticker, {
+        "overall_score": 3.0,
+        "rating": "Narrow",
+        "confidence": "Medium",
+        "factors": {
+            "network_effects": 3.0,
+            "switching_costs": 3.0,
+            "intangible_assets": 3.0,
+            "cost_advantages": 3.0,
+            "regulatory_barriers": 3.0,
+        },
+        "trend": "stable",
+        "summary": f"{ticker} exhibits moderate competitive advantages with room for strengthening across multiple moat factors."
+    })
+    
+    return {
+        **score_data,
+        "time_range": f"{start_date} to {end_date}",
+        "computed_at": datetime.utcnow().isoformat(),
+        "from_cache": False,
+    }

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,24 +9,30 @@ from __future__ import annotations
 import os
 from functools import lru_cache
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
     """
     Application settings loaded from environment variables.
-    
+
     All settings are loaded from .env file or environment variables.
     See env.example for available configuration options.
+
+    openai_api_key is only required when llm_provider="openai".
+    When llm_provider="local" (Ollama), OpenAI key is not used.
     """
-    
+
     # LLM Provider Configuration
     llm_provider: str = Field(default="openai", description="LLM provider (openai or local)")
     llm_streaming: bool = Field(default=True, description="Enable streaming responses")
-    
-    # OpenAI Configuration
-    openai_api_key: str = Field(..., description="OpenAI API key (required)")
+
+    # OpenAI Configuration (required only when llm_provider="openai")
+    openai_api_key: str | None = Field(
+        default=None,
+        description="OpenAI API key (required when llm_provider=openai)",
+    )
     openai_model: str = Field(default="gpt-5-nano", description="OpenAI model to use")
     
     # Local Model Configuration
@@ -39,9 +45,18 @@ class Settings(BaseSettings):
     # Streaming Configuration
     stream_token_delay_ms: int = Field(
         default=0,
-        description="Artificial delay between stream tokens (for testing)"
+        description="Artificial delay between stream tokens (for testing)",
     )
-    
+
+    @model_validator(mode="after")
+    def require_openai_key_when_openai_provider(self) -> "Settings":
+        if self.llm_provider == "openai" and not (self.openai_api_key or "").strip():
+            raise ValueError(
+                "openai_api_key is required when llm_provider is 'openai'. "
+                "Set OPENAI_API_KEY in .env or use llm_provider=local for Ollama."
+            )
+        return self
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from api.routes import chat, companies, analysis, sessions, health, charts, audio, windowed
+from api.routes import chat, companies, analysis, sessions, health, charts, audio, windowed, moat
 from middleware.logging import LoggingMiddleware
 
 
@@ -50,6 +50,7 @@ def create_app() -> FastAPI:
     app.include_router(charts.router)  # /api/v1/charts
     app.include_router(audio.router)  # /api/audio
     app.include_router(windowed.router)  # /api/v1/moat/windowed
+    app.include_router(moat.router)  # /api/v1/moat/overall
 
     @app.get("/", tags=["root"])
     async def root() -> dict:

--- a/backend/services/data_driven_moat_scorer.py
+++ b/backend/services/data_driven_moat_scorer.py
@@ -1,0 +1,479 @@
+"""
+Data-Driven Moat Scorer
+
+Calculates moat scores for companies using real historical data:
+- Stock price data (yfinance): returns, volatility, drawdowns, trends
+- News data (FNSPID): volume, sentiment indicators
+
+This provides quantitative, data-backed moat scores instead of mock values.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from services.stock_data import StockDataService
+from services.fnspid_retrieval import (
+    is_fnspid_data_available,
+    get_passage_count,
+    get_date_range,
+)
+
+logger = logging.getLogger(__name__)
+
+# Analysis period for moat scores (fixed)
+MOAT_START_DATE = "2015-01-01"
+MOAT_END_DATE = "2025-12-31"
+
+
+class DataDrivenMoatScorer:
+    """
+    Calculate moat scores using real historical data.
+    
+    Scoring methodology:
+    - Each factor scored 0-5 based on quantitative metrics
+    - Base score of 2.5 (neutral) with bonuses/penalties
+    - Uses 10-year historical data (2015-2025) for consistency
+    """
+    
+    def __init__(self):
+        self.stock_service = StockDataService()
+    
+    def calculate_moat_score(
+        self,
+        ticker: str,
+        start_date: str = MOAT_START_DATE,
+        end_date: str = MOAT_END_DATE
+    ) -> dict:
+        """
+        Calculate comprehensive moat score for a ticker.
+        
+        Args:
+            ticker: Stock ticker symbol
+            start_date: Analysis start date (default: 2015-01-01)
+            end_date: Analysis end date (default: 2025-12-31)
+            
+        Returns:
+            Dict with overall_score, rating, confidence, factors, trend, summary
+        """
+        ticker = ticker.upper()
+        logger.info(f"Calculating moat score for {ticker} ({start_date} to {end_date})")
+        
+        try:
+            # Load price data
+            df = self.stock_service.load_ticker_data(
+                ticker=ticker,
+                start_date=start_date,
+                end_date=end_date
+            )
+            
+            if df.empty or len(df) < 30:
+                logger.warning(f"Insufficient price data for {ticker}, using default score")
+                return self._get_default_score(ticker)
+            
+            # Calculate price metrics
+            price_metrics = self._calculate_price_metrics(df)
+            
+            # Check for news data
+            has_news = is_fnspid_data_available(ticker)
+            news_metrics = self._calculate_news_metrics(ticker) if has_news else {}
+            
+            # Calculate moat factors
+            factors = {
+                "network_effects": self._score_network_effects(price_metrics, news_metrics),
+                "switching_costs": self._score_switching_costs(price_metrics, news_metrics),
+                "intangible_assets": self._score_intangible_assets(price_metrics, news_metrics),
+                "cost_advantages": self._score_cost_advantages(price_metrics, news_metrics),
+                "regulatory_barriers": self._score_regulatory_barriers(price_metrics, news_metrics),
+            }
+            
+            # Calculate overall score and rating
+            overall_score = np.mean(list(factors.values()))
+            rating = self._determine_rating(overall_score, factors)
+            confidence = self._determine_confidence(price_metrics, has_news)
+            trend = self._determine_trend(price_metrics)
+            summary = self._generate_summary(ticker, overall_score, rating, factors, trend)
+            
+            return {
+                "overall_score": round(overall_score, 2),
+                "rating": rating,
+                "confidence": confidence,
+                "factors": factors,
+                "trend": trend,
+                "summary": summary,
+                "time_range": f"{start_date} to {end_date}",
+                "computed_at": datetime.utcnow().isoformat(),
+                "from_cache": False,
+            }
+            
+        except Exception as e:
+            logger.error(f"Error calculating moat score for {ticker}: {e}")
+            return self._get_default_score(ticker)
+    
+    def _calculate_price_metrics(self, df: pd.DataFrame) -> dict:
+        """Calculate key price metrics for moat analysis."""
+        metrics = {}
+        
+        # Returns
+        df['returns'] = df['close'].pct_change()
+        metrics['total_return'] = (df['close'].iloc[-1] / df['close'].iloc[0]) - 1
+        metrics['cagr'] = ((df['close'].iloc[-1] / df['close'].iloc[0]) ** (252 / len(df)) - 1) * 100
+        metrics['annual_return'] = df['returns'].mean() * 252 * 100
+        
+        # Volatility
+        metrics['volatility'] = df['returns'].std() * np.sqrt(252) * 100
+        metrics['downside_volatility'] = df['returns'][df['returns'] < 0].std() * np.sqrt(252) * 100
+        
+        # Risk metrics
+        metrics['max_drawdown'] = self._calculate_max_drawdown(df['close'])
+        metrics['sharpe_ratio'] = (metrics['annual_return'] - 2.0) / metrics['volatility'] if metrics['volatility'] > 0 else 0
+        
+        # Stability metrics
+        monthly_returns = df['returns'].resample('ME').sum()
+        metrics['positive_months_pct'] = (monthly_returns > 0).sum() / len(monthly_returns) * 100 if len(monthly_returns) > 0 else 50
+        metrics['return_consistency'] = 1 / (1 + df['returns'].std()) if df['returns'].std() > 0 else 0.5
+        
+        # Recent trend (last 2 years)
+        if len(df) >= 504:  # ~2 years of data
+            recent_df = df.iloc[-504:]
+            metrics['recent_return'] = (recent_df['close'].iloc[-1] / recent_df['close'].iloc[0]) - 1
+        else:
+            metrics['recent_return'] = metrics['total_return']
+        
+        return metrics
+    
+    def _calculate_max_drawdown(self, prices: pd.Series) -> float:
+        """Calculate maximum drawdown percentage."""
+        cummax = prices.cummax()
+        drawdown = (prices - cummax) / cummax
+        return abs(drawdown.min()) * 100 if not drawdown.empty else 0
+    
+    def _calculate_news_metrics(self, ticker: str) -> dict:
+        """Calculate news-based metrics for moat analysis."""
+        metrics = {}
+        
+        try:
+            # Get passage count (proxy for news volume)
+            passage_count = get_passage_count(ticker)
+            metrics['news_volume'] = passage_count
+            
+            # Get date range
+            min_date, max_date = get_date_range(ticker)
+            if min_date and max_date:
+                metrics['news_coverage_years'] = (
+                    datetime.fromisoformat(max_date).year - 
+                    datetime.fromisoformat(min_date).year
+                )
+            else:
+                metrics['news_coverage_years'] = 0
+            
+            # News volume per year (proxy for market attention)
+            if metrics['news_coverage_years'] > 0:
+                metrics['news_per_year'] = passage_count / max(metrics['news_coverage_years'], 1)
+            else:
+                metrics['news_per_year'] = 0
+            
+        except Exception as e:
+            logger.warning(f"Could not calculate news metrics for {ticker}: {e}")
+            metrics = {'news_volume': 0, 'news_coverage_years': 0, 'news_per_year': 0}
+        
+        return metrics
+    
+    # ========================================================================
+    # Factor Scoring Methods
+    # ========================================================================
+    
+    def _score_network_effects(self, price: dict, news: dict) -> float:
+        """
+        Score network effects based on consistent growth and market attention.
+        
+        Strong network effects show:
+        - Consistent positive returns (more users = more value)
+        - Growing news coverage (network expansion)
+        - Above-average Sharpe ratio (quality growth)
+        """
+        score = 2.5  # Base neutral score
+        
+        # Bonus for strong consistent returns
+        if price.get('annual_return', 0) > 15:
+            score += 0.8
+        elif price.get('annual_return', 0) > 8:
+            score += 0.4
+        
+        # Bonus for high positive month ratio (consistent growth)
+        if price.get('positive_months_pct', 50) > 60:
+            score += 0.6
+        elif price.get('positive_months_pct', 50) > 55:
+            score += 0.3
+        
+        # Bonus for quality growth (high Sharpe)
+        if price.get('sharpe_ratio', 0) > 1.5:
+            score += 0.6
+        elif price.get('sharpe_ratio', 0) > 1.0:
+            score += 0.3
+        
+        # Bonus for news volume (market attention)
+        news_per_year = news.get('news_per_year', 0)
+        if news_per_year > 2000:
+            score += 0.5
+        elif news_per_year > 1000:
+            score += 0.3
+        
+        return min(5.0, max(1.0, round(score, 1)))
+    
+    def _score_switching_costs(self, price: dict, news: dict) -> float:
+        """
+        Score switching costs based on revenue stability and low churn indicators.
+        
+        High switching costs show:
+        - Low drawdowns (customers don't leave during tough times)
+        - Low downside volatility (stable revenue base)
+        - Consistent returns (predictable business)
+        """
+        score = 2.5
+        
+        # Bonus for shallow drawdowns (customer stickiness)
+        max_dd = price.get('max_drawdown', 50)
+        if max_dd < 20:
+            score += 1.0
+        elif max_dd < 30:
+            score += 0.6
+        elif max_dd < 40:
+            score += 0.3
+        
+        # Bonus for low downside volatility
+        downside_vol = price.get('downside_volatility', 50)
+        if downside_vol < 20:
+            score += 0.8
+        elif downside_vol < 30:
+            score += 0.4
+        
+        # Bonus for return consistency
+        if price.get('return_consistency', 0) > 0.6:
+            score += 0.7
+        elif price.get('return_consistency', 0) > 0.5:
+            score += 0.4
+        
+        return min(5.0, max(1.0, round(score, 1)))
+    
+    def _score_intangible_assets(self, price: dict, news: dict) -> float:
+        """
+        Score intangible assets (brand, patents, IP) based on premium valuation.
+        
+        Strong intangibles show:
+        - High long-term CAGR (premium pricing power)
+        - Lower volatility (trust and brand loyalty)
+        - Strong total returns (market recognizes value)
+        """
+        score = 2.5
+        
+        # Bonus for strong CAGR (pricing power)
+        cagr = price.get('cagr', 0)
+        if cagr > 20:
+            score += 1.2
+        elif cagr > 12:
+            score += 0.7
+        elif cagr > 8:
+            score += 0.4
+        
+        # Bonus for total return (long-term value creation)
+        total_return = price.get('total_return', 0)
+        if total_return > 2.0:  # >200%
+            score += 0.8
+        elif total_return > 1.0:  # >100%
+            score += 0.4
+        
+        # Bonus for lower volatility (brand stability)
+        vol = price.get('volatility', 50)
+        if vol < 25:
+            score += 0.5
+        elif vol < 35:
+            score += 0.3
+        
+        return min(5.0, max(1.0, round(score, 1)))
+    
+    def _score_cost_advantages(self, price: dict, news: dict) -> float:
+        """
+        Score cost advantages based on margin proxies and performance.
+        
+        Cost advantages show:
+        - Above-market returns (operating leverage)
+        - Strong Sharpe ratio (efficient operations)
+        - Positive recent trend (maintaining advantage)
+        """
+        score = 2.5
+        
+        # Bonus for strong annual returns (margin expansion)
+        annual_return = price.get('annual_return', 0)
+        if annual_return > 20:
+            score += 1.0
+        elif annual_return > 12:
+            score += 0.6
+        elif annual_return > 8:
+            score += 0.3
+        
+        # Bonus for efficiency (high Sharpe)
+        sharpe = price.get('sharpe_ratio', 0)
+        if sharpe > 1.5:
+            score += 0.8
+        elif sharpe > 1.0:
+            score += 0.4
+        
+        # Bonus for maintaining advantage (recent performance)
+        recent_return = price.get('recent_return', 0)
+        if recent_return > 0.5:  # >50% in 2 years
+            score += 0.7
+        elif recent_return > 0.2:  # >20%
+            score += 0.4
+        
+        return min(5.0, max(1.0, round(score, 1)))
+    
+    def _score_regulatory_barriers(self, price: dict, news: dict) -> float:
+        """
+        Score regulatory barriers based on stability and predictability.
+        
+        Regulatory moats show:
+        - Low volatility (stable regulated environment)
+        - Shallow drawdowns (protected from competition)
+        - Consistent returns (predictable cash flows)
+        """
+        score = 2.5
+        
+        # Bonus for low overall volatility
+        vol = price.get('volatility', 50)
+        if vol < 20:
+            score += 1.0
+        elif vol < 30:
+            score += 0.6
+        elif vol < 40:
+            score += 0.3
+        
+        # Bonus for shallow drawdowns (protection)
+        max_dd = price.get('max_drawdown', 50)
+        if max_dd < 25:
+            score += 0.8
+        elif max_dd < 35:
+            score += 0.4
+        
+        # Bonus for return consistency
+        consistency = price.get('return_consistency', 0)
+        if consistency > 0.6:
+            score += 0.7
+        elif consistency > 0.5:
+            score += 0.4
+        
+        return min(5.0, max(1.0, round(score, 1)))
+    
+    # ========================================================================
+    # Rating and Summary Methods
+    # ========================================================================
+    
+    def _determine_rating(self, overall_score: float, factors: dict) -> str:
+        """Determine Wide/Narrow/None rating from scores."""
+        strong_factors = sum(1 for score in factors.values() if score >= 4.0)
+        
+        if overall_score >= 4.0 and strong_factors >= 2:
+            return "Wide"
+        elif overall_score >= 3.5 and strong_factors >= 1:
+            return "Wide"
+        elif overall_score < 2.5:
+            return "None"
+        else:
+            return "Narrow"
+    
+    def _determine_confidence(self, price: dict, has_news: bool) -> str:
+        """Determine confidence level based on data availability and quality."""
+        data_points = len([v for v in price.values() if v is not None])
+        
+        # High confidence: full data + news
+        if data_points >= 10 and has_news:
+            return "High"
+        # Medium confidence: good price data
+        elif data_points >= 8:
+            return "Medium"
+        # Low confidence: limited data
+        else:
+            return "Low"
+    
+    def _determine_trend(self, price: dict) -> str:
+        """Determine moat trend from recent performance."""
+        recent_return = price.get('recent_return', 0)
+        total_return = price.get('total_return', 0)
+        
+        # Compare recent to overall performance
+        if len([r for r in [recent_return, total_return] if r is not None]) < 2:
+            return "stable"
+        
+        # Strengthening if recent outperforms historical
+        if recent_return > total_return * 0.4:  # Recent is strong relative to total
+            return "strengthening"
+        # Weakening if recent underperforms
+        elif recent_return < total_return * 0.1:
+            return "weakening"
+        else:
+            return "stable"
+    
+    def _generate_summary(
+        self,
+        ticker: str,
+        overall_score: float,
+        rating: str,
+        factors: dict,
+        trend: str
+    ) -> str:
+        """Generate human-readable summary of moat analysis."""
+        # Find strongest factors
+        sorted_factors = sorted(factors.items(), key=lambda x: x[1], reverse=True)
+        top_factors = [name.replace('_', ' ').title() for name, score in sorted_factors[:2]]
+        
+        # Build summary
+        if rating == "Wide":
+            summary = f"{ticker} demonstrates a wide moat "
+        elif rating == "Narrow":
+            summary = f"{ticker} exhibits a narrow moat "
+        else:
+            summary = f"{ticker} shows limited moat characteristics "
+        
+        summary += f"with strengths in {top_factors[0]}"
+        if len(top_factors) > 1:
+            summary += f" and {top_factors[1]}"
+        
+        summary += ". "
+        
+        # Add trend
+        if trend == "strengthening":
+            summary += "The competitive position has strengthened in recent years, "
+        elif trend == "weakening":
+            summary += "The competitive position has faced some erosion recently, "
+        else:
+            summary += "The competitive position has remained stable, "
+        
+        # Add score context
+        summary += f"supported by quantitative analysis of 2015-2025 market data (score: {overall_score:.1f}/5.0)."
+        
+        return summary
+    
+    def _get_default_score(self, ticker: str) -> dict:
+        """Return default/fallback score when data is insufficient."""
+        return {
+            "overall_score": 3.0,
+            "rating": "Narrow",
+            "confidence": "Low",
+            "factors": {
+                "network_effects": 3.0,
+                "switching_costs": 3.0,
+                "intangible_assets": 3.0,
+                "cost_advantages": 3.0,
+                "regulatory_barriers": 3.0,
+            },
+            "trend": "stable",
+            "summary": f"{ticker} analysis limited by insufficient historical data. Default neutral scores applied pending more comprehensive data coverage.",
+            "time_range": f"{MOAT_START_DATE} to {MOAT_END_DATE}",
+            "computed_at": datetime.utcnow().isoformat(),
+            "from_cache": False,
+        }

--- a/backend/test_real_moat_scores.py
+++ b/backend/test_real_moat_scores.py
@@ -1,0 +1,83 @@
+"""
+Test script for real data-driven moat scores.
+
+Tests the new moat scoring system with various companies.
+"""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from services.data_driven_moat_scorer import DataDrivenMoatScorer
+
+def print_moat_score(ticker: str, score_data: dict):
+    """Pretty print moat score results."""
+    print(f"\n{'='*80}")
+    print(f"MOAT ANALYSIS: {ticker}")
+    print(f"{'='*80}")
+    print(f"Overall Score: {score_data['overall_score']:.2f}/5.0")
+    print(f"Rating: {score_data['rating']}")
+    print(f"Confidence: {score_data['confidence']}")
+    print(f"Trend: {score_data['trend']}")
+    print(f"Time Range: {score_data['time_range']}")
+    print(f"\nMoat Factors:")
+    print(f"  Network Effects:      {score_data['factors']['network_effects']:.1f}")
+    print(f"  Switching Costs:      {score_data['factors']['switching_costs']:.1f}")
+    print(f"  Intangible Assets:    {score_data['factors']['intangible_assets']:.1f}")
+    print(f"  Cost Advantages:      {score_data['factors']['cost_advantages']:.1f}")
+    print(f"  Regulatory Barriers:  {score_data['factors']['regulatory_barriers']:.1f}")
+    print(f"\nSummary:")
+    print(f"  {score_data['summary']}")
+    print(f"{'='*80}\n")
+
+
+def test_moat_scores():
+    """Test moat scoring for various companies."""
+    print("=" * 80)
+    print("TESTING DATA-DRIVEN MOAT SCORER")
+    print("=" * 80)
+    
+    scorer = DataDrivenMoatScorer()
+    
+    # Test companies with FNSPID data
+    companies_with_news = ['NVDA', 'AAPL', 'MSFT', 'GOOGL', 'AMD']
+    
+    # Test companies without FNSPID data
+    companies_without_news = ['MU', 'AVGO', 'ORCL', 'CSCO', 'PLTR']
+    
+    print("\n" + "="*80)
+    print("TESTING COMPANIES WITH HISTORICAL NEWS DATA (FNSPID)")
+    print("="*80)
+    
+    for ticker in companies_with_news:
+        try:
+            score_data = scorer.calculate_moat_score(ticker)
+            print_moat_score(ticker, score_data)
+        except Exception as e:
+            print(f"\nERROR testing {ticker}: {e}\n")
+    
+    print("\n" + "="*80)
+    print("TESTING COMPANIES WITHOUT FNSPID (PRICE DATA ONLY)")
+    print("="*80)
+    
+    for ticker in companies_without_news:
+        try:
+            score_data = scorer.calculate_moat_score(ticker)
+            print_moat_score(ticker, score_data)
+        except Exception as e:
+            print(f"\nERROR testing {ticker}: {e}\n")
+    
+    print("\n" + "="*80)
+    print("TESTING COMPLETE")
+    print("="*80)
+    print("\nKey findings:")
+    print("- Companies should now have DIFFERENT scores based on real data")
+    print("- Scores should reflect actual 2015-2025 performance")
+    print("- No more generic '3.0' defaults for all companies")
+    print("="*80)
+
+
+if __name__ == "__main__":
+    test_moat_scores()

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -185,6 +185,12 @@ export default function Home() {
           startDate={startDate}
           endDate={endDate}
           moatAssessment={moatAssessment}
+          selectedCompanyId={selectedCompanyId}
+          onCompanyChange={setSelectedCompanyId}
+          startYear={startYear}
+          endYear={endYear}
+          onStartYearChange={setStartYear}
+          onEndYearChange={setEndYear}
         />
       )}
     </main>

--- a/frontend/src/components/ActiveShell.tsx
+++ b/frontend/src/components/ActiveShell.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState } from "react";
 import { Message } from "@/types/chat";
-import { ChatInput, MessageBubble } from "@/components/chat";
-import { MoatDashboard } from "@/components/dashboard";
 import { MoatAssessment } from "@/lib/moatTutorApi";
+import { ThreeColumnLayout } from "@/components/ThreeColumnLayout";
 
 type ActiveShellProps = {
   messages: Message[];
@@ -14,6 +12,12 @@ type ActiveShellProps = {
   startDate?: string | null;
   endDate?: string | null;
   moatAssessment?: MoatAssessment | null;
+  selectedCompanyId: string | null;
+  onCompanyChange: (id: string | null) => void;
+  startYear: number;
+  endYear: number;
+  onStartYearChange: (year: number) => void;
+  onEndYearChange: (year: number) => void;
 };
 
 export function ActiveShell({
@@ -26,95 +30,31 @@ export function ActiveShell({
   startDate,
   endDate,
   moatAssessment,
+  selectedCompanyId,
+  onCompanyChange,
+  startYear,
+  endYear,
+  onStartYearChange,
+  onEndYearChange,
 }: ActiveShellProps) {
-  const [showPanel, setShowPanel] = useState(false);
-
-  useEffect(() => {
-    // Show panel after first user message is sent
-    if (messages.length > 0) {
-      // Delay the panel opening slightly to create a staged animation
-      const timer = setTimeout(() => {
-        setShowPanel(true);
-      }, 400);
-      return () => clearTimeout(timer);
-    }
-  }, [messages.length]);
-
   return (
-    <div className="mx-auto flex w-full flex-col gap-6 lg:flex-row mt-16 sm:mt-20" style={{ maxWidth: showPanel ? "96rem" : "48rem", transition: "max-width 600ms cubic-bezier(0.4, 0, 0.2, 1)" }}>
-      <section
-        className="flex h-[75vh] flex-col rounded-[36px] border p-6 backdrop-blur-3xl"
-        style={{
-          borderColor: "var(--border)",
-          backgroundColor: "color-mix(in srgb, var(--surface) 75%, transparent)",
-          flexBasis: showPanel ? "32%" : "100%",
-          transition: "flex-basis 600ms cubic-bezier(0.4, 0, 0.2, 1)",
-          flexShrink: 0,
-        }}
-      >
-        <div
-          className="rounded-[28px] border p-5"
-          style={{
-            borderColor: "var(--border)",
-            backgroundColor: "var(--border-subtle)",
-          }}
-        >
-          <p
-            className="text-xs uppercase tracking-[0.4em]"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            Conversation
-          </p>
-          <h2
-            className="mt-3 text-2xl font-semibold"
-            style={{ color: "var(--text-primary)" }}
-          >
-            AI Research Chat
-          </h2>
-          <p className="mt-1 text-sm" style={{ color: "var(--text-secondary)" }}>
-            Your questions drive the moat analysis. Each answer triggers a new
-            panel on the right.
-          </p>
-        </div>
-
-        <div
-          ref={chatScrollRef}
-          className="scrollbar-hide mt-6 flex-1 min-h-0 space-y-4 overflow-y-auto pr-2"
-        >
-          {messages.map((message) => (
-            <MessageBubble key={message.id} message={message} />
-          ))}
-        </div>
-
-        <div className="mt-6">
-          <ChatInput
-            value={inputValue}
-            onChange={onInputChange}
-            onSubmit={() => onSubmit()}
-            variant="active"
-          />
-        </div>
-      </section>
-
-      <section 
-        className="flex overflow-hidden"
-        style={{
-          flexBasis: showPanel ? "calc(68% - 1.5rem)" : "0%",
-          transition: "flex-basis 600ms cubic-bezier(0.4, 0, 0.2, 1) 200ms",
-        }}
-      >
-        {showPanel && (
-          <div className="slide-in-panel w-full">
-            <MoatDashboard 
-              ticker={ticker} 
-              startDate={startDate} 
-              endDate={endDate} 
-              initialMoatAssessment={moatAssessment}
-            />
-          </div>
-        )}
-      </section>
-    </div>
+    <ThreeColumnLayout
+      messages={messages}
+      inputValue={inputValue}
+      onInputChange={onInputChange}
+      onSubmit={onSubmit}
+      chatScrollRef={chatScrollRef}
+      ticker={ticker}
+      startDate={startDate}
+      endDate={endDate}
+      moatAssessment={moatAssessment}
+      selectedCompanyId={selectedCompanyId}
+      onCompanyChange={onCompanyChange}
+      startYear={startYear}
+      endYear={endYear}
+      onStartYearChange={onStartYearChange}
+      onEndYearChange={onEndYearChange}
+    />
   );
 }
 

--- a/frontend/src/components/CompanySelectorCompact.tsx
+++ b/frontend/src/components/CompanySelectorCompact.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { availableCompanies } from "@/constants/companies";
+
+type CompanySelectorCompactProps = {
+  selectedCompanyId: string | null;
+  onCompanyChange: (companyId: string | null) => void;
+};
+
+export function CompanySelectorCompact({
+  selectedCompanyId,
+  onCompanyChange,
+}: CompanySelectorCompactProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const selectedCompany = selectedCompanyId
+    ? availableCompanies.find((c) => c.id === selectedCompanyId)
+    : null;
+
+  // Filter companies based on search query
+  const filteredCompanies = availableCompanies.filter((company) =>
+    company.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    company.ticker.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+        setSearchQuery("");
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelectCompany = (companyId: string) => {
+    onCompanyChange(companyId);
+    setIsOpen(false);
+    setSearchQuery("");
+  };
+
+  return (
+    <div className="relative w-full">
+      {/* Trigger Button */}
+      <button
+        ref={buttonRef}
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full rounded-lg border px-3 py-2 text-left transition-all hover:border-opacity-80"
+        style={{
+          borderColor: selectedCompany ? "var(--accent)" : "var(--border)",
+          backgroundColor: "var(--background)",
+          color: "var(--text-primary)",
+        }}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            {selectedCompany ? (
+              <>
+                <p className="text-sm font-semibold truncate">{selectedCompany.ticker}</p>
+                <p className="text-xs truncate" style={{ color: "var(--text-tertiary)" }}>
+                  {selectedCompany.name}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+                Select company...
+              </p>
+            )}
+          </div>
+          <svg
+            className={`flex-shrink-0 h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </button>
+
+      {/* Dropdown Menu */}
+      {isOpen && (
+        <div
+          ref={dropdownRef}
+          className="absolute z-50 mt-2 w-full rounded-lg border shadow-lg animate-in fade-in slide-in-from-top-2 duration-200"
+          style={{
+            borderColor: "var(--border)",
+            backgroundColor: "var(--background)",
+          }}
+        >
+          {/* Search Input */}
+          <div className="p-2 border-b" style={{ borderColor: "var(--border)" }}>
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search..."
+              className="w-full rounded px-2 py-1.5 text-sm border focus:outline-none focus:ring-1"
+              style={{
+                borderColor: "var(--border)",
+                backgroundColor: "var(--surface)",
+                color: "var(--text-primary)",
+              }}
+              autoFocus
+            />
+          </div>
+
+          {/* Company List */}
+          <div className="max-h-64 overflow-y-auto">
+            {filteredCompanies.length > 0 ? (
+              filteredCompanies.map((company) => (
+                <button
+                  key={company.id}
+                  type="button"
+                  onClick={() => handleSelectCompany(company.id)}
+                  className="w-full px-3 py-2 text-left transition-colors hover:bg-opacity-50"
+                  style={{
+                    backgroundColor:
+                      selectedCompanyId === company.id
+                        ? "color-mix(in srgb, var(--accent) 15%, transparent)"
+                        : "transparent",
+                    color: "var(--text-primary)",
+                  }}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold truncate">{company.ticker}</p>
+                      <p className="text-xs truncate" style={{ color: "var(--text-tertiary)" }}>
+                        {company.name}
+                      </p>
+                    </div>
+                    {selectedCompanyId === company.id && (
+                      <div
+                        className="h-2 w-2 rounded-full flex-shrink-0"
+                        style={{ backgroundColor: "var(--accent)" }}
+                      />
+                    )}
+                  </div>
+                </button>
+              ))
+            ) : (
+              <div className="px-3 py-4 text-center text-xs" style={{ color: "var(--text-secondary)" }}>
+                No companies found
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/DateRangePickerCompact.tsx
+++ b/frontend/src/components/DateRangePickerCompact.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+type DateRangePickerCompactProps = {
+  startYear: number;
+  endYear: number;
+  onStartYearChange: (year: number) => void;
+  onEndYearChange: (year: number) => void;
+};
+
+const MIN_YEAR = 2015;
+const MAX_YEAR = 2025;
+
+export function DateRangePickerCompact({
+  startYear,
+  endYear,
+  onStartYearChange,
+  onEndYearChange,
+}: DateRangePickerCompactProps) {
+  const [localStartYear, setLocalStartYear] = useState(startYear);
+  const [localEndYear, setLocalEndYear] = useState(endYear);
+
+  useEffect(() => {
+    setLocalStartYear(startYear);
+  }, [startYear]);
+
+  useEffect(() => {
+    setLocalEndYear(endYear);
+  }, [endYear]);
+
+  const handleStartChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newStart = parseInt(e.target.value);
+    if (newStart <= localEndYear) {
+      setLocalStartYear(newStart);
+      onStartYearChange(newStart);
+    }
+  };
+
+  const handleEndChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newEnd = parseInt(e.target.value);
+    if (newEnd >= localStartYear) {
+      setLocalEndYear(newEnd);
+      onEndYearChange(newEnd);
+    }
+  };
+
+  const totalYears = MAX_YEAR - MIN_YEAR;
+  const startPercent = ((localStartYear - MIN_YEAR) / totalYears) * 100;
+  const endPercent = ((localEndYear - MIN_YEAR) / totalYears) * 100;
+  const fillWidthPercent = endPercent - startPercent;
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Year Display */}
+      <div className="flex items-center justify-between text-xs">
+        <div>
+          <span className="font-semibold" style={{ color: "var(--text-primary)" }}>
+            {localStartYear}
+          </span>
+          <span className="ml-1" style={{ color: "var(--text-tertiary)" }}>
+            Start
+          </span>
+        </div>
+        <div>
+          <span className="font-semibold" style={{ color: "var(--text-primary)" }}>
+            {localEndYear}
+          </span>
+          <span className="ml-1" style={{ color: "var(--text-tertiary)" }}>
+            End
+          </span>
+        </div>
+      </div>
+
+      {/* Dual Range Slider */}
+      <div className="relative" style={{ height: "32px", paddingTop: "12px", paddingBottom: "12px" }}>
+        {/* Track Background */}
+        <div
+          className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full"
+          style={{
+            backgroundColor: "var(--border)",
+            zIndex: 1,
+            left: 0,
+            right: 0,
+          }}
+        />
+
+        {/* Selected Range Fill */}
+        <div
+          className="absolute top-1/2 h-2 -translate-y-1/2 rounded-full transition-all duration-150"
+          style={{
+            left: `${startPercent}%`,
+            width: `${fillWidthPercent}%`,
+            backgroundColor: "var(--accent)",
+            zIndex: 2,
+          }}
+        />
+
+        {/* Start Year Slider */}
+        <input
+          type="range"
+          min={MIN_YEAR}
+          max={MAX_YEAR}
+          value={localStartYear}
+          onChange={handleStartChange}
+          className="range-slider-dual absolute top-1/2 -translate-y-1/2 cursor-pointer"
+          style={{
+            zIndex: 3,
+            height: "16px",
+            width: "100%",
+          }}
+        />
+
+        {/* End Year Slider */}
+        <input
+          type="range"
+          min={MIN_YEAR}
+          max={MAX_YEAR}
+          value={localEndYear}
+          onChange={handleEndChange}
+          className="range-slider-dual absolute top-1/2 -translate-y-1/2 cursor-pointer"
+          style={{
+            zIndex: 4,
+            height: "16px",
+            width: "100%",
+          }}
+        />
+      </div>
+
+      {/* Year Labels */}
+      <div className="flex justify-between text-xs" style={{ color: "var(--text-tertiary)" }}>
+        <span>{MIN_YEAR}</span>
+        <span>{Math.floor((MIN_YEAR + MAX_YEAR) / 2)}</span>
+        <span>{MAX_YEAR}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+type EmptyStateProps = {
+  icon?: React.ReactNode;
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+};
+
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="text-center max-w-xs">
+        {icon && (
+          <div className="mb-4 flex justify-center" style={{ color: "var(--text-tertiary)" }}>
+            {icon}
+          </div>
+        )}
+        <h3
+          className="text-sm font-semibold mb-2"
+          style={{ color: "var(--text-primary)" }}
+        >
+          {title}
+        </h3>
+        {description && (
+          <p className="text-xs mb-4" style={{ color: "var(--text-secondary)" }}>
+            {description}
+          </p>
+        )}
+        {action && (
+          <button
+            onClick={action.onClick}
+            className="px-4 py-2 rounded-lg text-xs font-semibold transition-all hover:opacity-80"
+            style={{
+              backgroundColor: "var(--accent)",
+              color: "white",
+            }}
+          >
+            {action.label}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StudioPanel.tsx
+++ b/frontend/src/components/StudioPanel.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import { MoatAssessment } from "@/lib/moatTutorApi";
+import { StudioCard } from "@/components/studio/StudioCard";
+import { StudioCardExpanded } from "@/components/studio/StudioCardExpanded";
+import { PriceChartView } from "@/components/studio/views/PriceChartView";
+import { MoatRadarView } from "@/components/studio/views/MoatRadarView";
+import { OverallMoatView } from "@/components/studio/views/OverallMoatView";
+
+type StudioPanelProps = {
+  ticker?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  moatAssessment?: MoatAssessment | null;
+  startYear?: number;
+  endYear?: number;
+};
+
+type CardId = "price-chart" | "moat-radar" | "overall-moat" | "news-timeline";
+
+export function StudioPanel({
+  ticker,
+  startDate,
+  endDate,
+  moatAssessment,
+  startYear,
+  endYear,
+}: StudioPanelProps) {
+  const [expandedCard, setExpandedCard] = useState<CardId | null>(null);
+  const [loadingCard, setLoadingCard] = useState<CardId | null>(null);
+
+  const handleCardClick = (cardId: CardId) => {
+    if (expandedCard === cardId) {
+      setExpandedCard(null);
+    } else {
+      setLoadingCard(cardId);
+      setExpandedCard(cardId);
+      // Clear loading after a short delay (actual loading handled by child components)
+      setTimeout(() => setLoadingCard(null), 300);
+    }
+  };
+
+  // Check if dates represent the full 2015-2025 range
+  const isFullRange =
+    startYear === 2015 && endYear === 2025;
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-1 overflow-y-auto pr-2 scrollbar-hide space-y-3">
+        {/* Overall Moat Score Card - Always first */}
+        {ticker && (
+          <>
+            <StudioCard
+              id="overall-moat"
+              title="Overall Moat Score"
+              description="Comprehensive moat analysis across full historical range (2015-2025)"
+              icon={
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M12 6v6l4 2" />
+                </svg>
+              }
+              available={!!ticker}
+              onClick={() => handleCardClick("overall-moat")}
+              isExpanded={expandedCard === "overall-moat"}
+              isLoading={loadingCard === "overall-moat"}
+            />
+            {expandedCard === "overall-moat" && (
+              <StudioCardExpanded onCollapse={() => setExpandedCard(null)}>
+                <OverallMoatView
+                  ticker={ticker}
+                  startDate={startDate}
+                  endDate={endDate}
+                  useFullRange={isFullRange}
+                />
+              </StudioCardExpanded>
+            )}
+          </>
+        )}
+
+        {/* Price Chart Card */}
+        <StudioCard
+          id="price-chart"
+          title="Price Chart"
+          description="Interactive price and volume analysis for selected period"
+          icon={
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M3 3v18h18" />
+              <path d="M18 17l-5-5-4 4-3-3" />
+            </svg>
+          }
+          available={!!ticker}
+          onClick={() => handleCardClick("price-chart")}
+          isExpanded={expandedCard === "price-chart"}
+          isLoading={loadingCard === "price-chart"}
+        />
+        {expandedCard === "price-chart" && (
+          <StudioCardExpanded onCollapse={() => setExpandedCard(null)}>
+            <PriceChartView ticker={ticker} startDate={startDate} endDate={endDate} />
+          </StudioCardExpanded>
+        )}
+
+        {/* Moat Radar Card */}
+        <StudioCard
+          id="moat-radar"
+          title="Moat Analysis"
+          description="Competitive moat characteristics from recent conversation"
+          icon={
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 2v20M2 12h20" />
+              <path d="M6.34 6.34l11.32 11.32M17.66 6.34L6.34 17.66" />
+            </svg>
+          }
+          available={!!moatAssessment}
+          onClick={() => handleCardClick("moat-radar")}
+          isExpanded={expandedCard === "moat-radar"}
+          isLoading={loadingCard === "moat-radar"}
+        />
+        {expandedCard === "moat-radar" && (
+          <StudioCardExpanded onCollapse={() => setExpandedCard(null)}>
+            <MoatRadarView moatAssessment={moatAssessment} />
+          </StudioCardExpanded>
+        )}
+
+        {/* News Timeline Card - Placeholder */}
+        <StudioCard
+          id="news-timeline"
+          title="News Timeline"
+          description="Key events and news correlation (coming soon)"
+          icon={
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+              <line x1="16" y1="2" x2="16" y2="6" />
+              <line x1="8" y1="2" x2="8" y2="6" />
+              <line x1="3" y1="10" x2="21" y2="10" />
+            </svg>
+          }
+          available={false}
+          onClick={() => {}}
+          isExpanded={false}
+          isLoading={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ThreeColumnLayout.tsx
+++ b/frontend/src/components/ThreeColumnLayout.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useState } from "react";
+import { Message } from "@/types/chat";
+import { ChatInput, MessageBubble } from "@/components/chat";
+import { StudioPanel } from "@/components/StudioPanel";
+import { MoatAssessment } from "@/lib/moatTutorApi";
+import { CompanySelectorCompact } from "@/components/CompanySelectorCompact";
+import { DateRangePickerCompact } from "@/components/DateRangePickerCompact";
+
+type ThreeColumnLayoutProps = {
+  messages: Message[];
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  onSubmit: (value?: string) => void;
+  chatScrollRef: React.MutableRefObject<HTMLDivElement | null>;
+  ticker?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  moatAssessment?: MoatAssessment | null;
+  selectedCompanyId: string | null;
+  onCompanyChange: (id: string | null) => void;
+  startYear: number;
+  endYear: number;
+  onStartYearChange: (year: number) => void;
+  onEndYearChange: (year: number) => void;
+};
+
+export function ThreeColumnLayout({
+  messages,
+  inputValue,
+  onInputChange,
+  onSubmit,
+  chatScrollRef,
+  ticker,
+  startDate,
+  endDate,
+  moatAssessment,
+  selectedCompanyId,
+  onCompanyChange,
+  startYear,
+  endYear,
+  onStartYearChange,
+  onEndYearChange,
+}: ThreeColumnLayoutProps) {
+  const [leftPanelOpen, setLeftPanelOpen] = useState(false);
+  const [rightPanelOpen, setRightPanelOpen] = useState(false);
+
+  return (
+    <div className="mx-auto flex w-full gap-4 mt-16 sm:mt-20" style={{ maxWidth: "100%", height: "calc(100vh - 8rem)" }}>
+      {/* LEFT PANEL - Sources */}
+      <aside
+        className={`flex-shrink-0 transition-all duration-300 ease-in-out overflow-hidden`}
+        style={{
+          width: leftPanelOpen ? "320px" : "0px",
+        }}
+      >
+        {leftPanelOpen && (
+          <div
+            className="h-full flex flex-col rounded-[28px] border p-6 backdrop-blur-3xl animate-in fade-in slide-in-from-left-4 duration-300"
+            style={{
+              borderColor: "var(--border)",
+              backgroundColor: "color-mix(in srgb, var(--surface) 85%, transparent)",
+            }}
+          >
+            {/* Header */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-2">
+                <h3
+                  className="text-xs uppercase tracking-[0.3em] font-semibold"
+                  style={{ color: "var(--text-secondary)" }}
+                >
+                  Sources
+                </h3>
+                <button
+                  onClick={() => setLeftPanelOpen(false)}
+                  className="p-1 rounded-lg hover:bg-opacity-20 transition-all"
+                  style={{ color: "var(--text-secondary)" }}
+                  title="Close sources panel"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                Select company and date range
+              </p>
+            </div>
+
+            {/* Company Selector */}
+            <div className="mb-6 flex-shrink-0">
+              <label
+                className="block text-xs uppercase tracking-wider mb-2 font-semibold"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                Company
+              </label>
+              <CompanySelectorCompact
+                selectedCompanyId={selectedCompanyId}
+                onCompanyChange={onCompanyChange}
+              />
+            </div>
+
+            {/* Date Range */}
+            <div className="flex-shrink-0">
+              <label
+                className="block text-xs uppercase tracking-wider mb-2 font-semibold"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                Date Range
+              </label>
+              <DateRangePickerCompact
+                startYear={startYear}
+                endYear={endYear}
+                onStartYearChange={onStartYearChange}
+                onEndYearChange={onEndYearChange}
+              />
+            </div>
+
+            {/* Selected Info Summary */}
+            {ticker && (
+              <div
+                className="mt-auto pt-4 border-t text-xs"
+                style={{
+                  borderColor: "var(--border)",
+                  color: "var(--text-tertiary)",
+                }}
+              >
+                <div className="space-y-1">
+                  <p>
+                    <span className="font-semibold" style={{ color: "var(--text-secondary)" }}>
+                      {ticker}
+                    </span>
+                  </p>
+                  <p>
+                    {startYear} - {endYear}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </aside>
+
+      {/* CENTER PANEL - Chat */}
+      <main className="flex-1 flex flex-col min-w-0">
+        <div
+          className="h-full flex flex-col rounded-[28px] border p-6 backdrop-blur-3xl"
+          style={{
+            borderColor: "var(--border)",
+            backgroundColor: "color-mix(in srgb, var(--surface) 75%, transparent)",
+          }}
+        >
+          {/* Header with toggle buttons */}
+          <div className="flex items-center gap-3 mb-6">
+            {/* Left Panel Toggle */}
+            <button
+              onClick={() => setLeftPanelOpen(!leftPanelOpen)}
+              className={`p-2 rounded-lg transition-all ${leftPanelOpen ? "bg-opacity-10" : ""}`}
+              style={{
+                color: leftPanelOpen ? "var(--accent)" : "var(--text-secondary)",
+                backgroundColor: leftPanelOpen ? "color-mix(in srgb, var(--accent) 10%, transparent)" : "transparent",
+              }}
+              title="Toggle sources panel"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="3" y="3" width="7" height="7" rx="1" />
+                <rect x="3" y="14" width="7" height="7" rx="1" />
+                <rect x="14" y="3" width="7" height="7" rx="1" />
+                <rect x="14" y="14" width="7" height="7" rx="1" />
+              </svg>
+            </button>
+
+            {/* Chat Title */}
+            <div className="flex-1">
+              <p
+                className="text-xs uppercase tracking-[0.3em]"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                Conversation
+              </p>
+              <h2
+                className="mt-1 text-xl font-semibold"
+                style={{ color: "var(--text-primary)" }}
+              >
+                AI Research Chat
+              </h2>
+            </div>
+
+            {/* Right Panel Toggle */}
+            <button
+              onClick={() => setRightPanelOpen(!rightPanelOpen)}
+              className={`p-2 rounded-lg transition-all ${rightPanelOpen ? "bg-opacity-10" : ""}`}
+              style={{
+                color: rightPanelOpen ? "var(--accent)" : "var(--text-secondary)",
+                backgroundColor: rightPanelOpen ? "color-mix(in srgb, var(--accent) 10%, transparent)" : "transparent",
+              }}
+              title="Toggle studio panel"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <line x1="9" y1="3" x2="9" y2="21" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Chat Messages */}
+          <div
+            ref={chatScrollRef}
+            className="scrollbar-hide flex-1 min-h-0 space-y-4 overflow-y-auto pr-2"
+          >
+            {messages.map((message) => (
+              <MessageBubble key={message.id} message={message} />
+            ))}
+          </div>
+
+          {/* Chat Input */}
+          <div className="mt-6 flex-shrink-0">
+            <ChatInput
+              value={inputValue}
+              onChange={onInputChange}
+              onSubmit={() => onSubmit()}
+              variant="active"
+            />
+          </div>
+        </div>
+      </main>
+
+      {/* RIGHT PANEL - Studio */}
+      <aside
+        className={`flex-shrink-0 transition-all duration-300 ease-in-out overflow-hidden`}
+        style={{
+          width: rightPanelOpen ? "480px" : "0px",
+        }}
+      >
+        {rightPanelOpen && (
+          <div
+            className="h-full flex flex-col rounded-[28px] border p-6 backdrop-blur-3xl animate-in fade-in slide-in-from-right-4 duration-300"
+            style={{
+              borderColor: "var(--border)",
+              backgroundColor: "color-mix(in srgb, var(--surface) 85%, transparent)",
+            }}
+          >
+            {/* Header */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-2">
+                <h3
+                  className="text-xs uppercase tracking-[0.3em] font-semibold"
+                  style={{ color: "var(--text-secondary)" }}
+                >
+                  Studio
+                </h3>
+                <button
+                  onClick={() => setRightPanelOpen(false)}
+                  className="p-1 rounded-lg hover:bg-opacity-20 transition-all"
+                  style={{ color: "var(--text-secondary)" }}
+                  title="Close studio panel"
+                >
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+                Visualizations and analytics
+              </p>
+            </div>
+
+            {/* Studio Content */}
+            <div className="flex-1 min-h-0">
+              <StudioPanel
+                ticker={ticker}
+                startDate={startDate}
+                endDate={endDate}
+                moatAssessment={moatAssessment}
+                startYear={startYear}
+                endYear={endYear}
+              />
+            </div>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/MoatDashboard.tsx
+++ b/frontend/src/components/dashboard/MoatDashboard.tsx
@@ -159,41 +159,38 @@ export function MoatDashboard({
     : 0;
 
   return (
-    <div
-      className="flex h-full flex-col gap-6 rounded-[36px] border p-6"
-      style={{
-        borderColor: "var(--border)",
-        backgroundColor: "color-mix(in srgb, var(--surface) 75%, transparent)",
-      }}
-    >
+    <div className="flex h-full flex-col gap-4">
       {/* Header Alert */}
-      <div className="rounded-2xl border p-4" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
-        <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: "var(--risk)" }}>
-          {ticker ? `${companyName} Price Analysis` : "Select a company to view analysis"}
+      <div className="rounded-xl border p-3" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
+        <h2 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--risk)" }}>
+          {ticker ? `${companyName} Analysis` : "Select a company"}
         </h2>
       </div>
 
-      {/* Main Content Grid */}
-      <div className="grid flex-1 grid-cols-1 gap-6 lg:grid-cols-2">
+      {/* Main Content Stack */}
+      <div className="flex-1 flex flex-col gap-4 overflow-y-auto pr-2 scrollbar-hide">
         {/* Stock Chart */}
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 flex-shrink-0">
+          <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-secondary)" }}>
+            Price Chart
+          </h3>
           <div
-            className="relative rounded-xl border p-4"
+            className="relative rounded-xl border p-3"
             style={{
               borderColor: "var(--border)",
               backgroundColor: "var(--background)",
-              minHeight: "300px",
+              minHeight: "220px",
             }}
           >
             {isLoading && (
               <div className="flex h-full items-center justify-center">
                 <div className="text-center">
                   <div
-                    className="mb-2 inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent"
+                    className="mb-2 inline-block h-6 w-6 animate-spin rounded-full border-4 border-solid border-current border-r-transparent"
                     style={{ color: "var(--accent)" }}
                   />
-                  <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                    Loading chart data...
+                  <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                    Loading...
                   </p>
                 </div>
               </div>
@@ -202,7 +199,7 @@ export function MoatDashboard({
             {error && (
               <div className="flex h-full items-center justify-center">
                 <div className="text-center">
-                  <p className="text-sm font-semibold" style={{ color: "var(--risk)" }}>
+                  <p className="text-xs font-semibold" style={{ color: "var(--risk)" }}>
                     Error loading chart
                   </p>
                   <p className="mt-1 text-xs" style={{ color: "var(--text-secondary)" }}>
@@ -213,27 +210,27 @@ export function MoatDashboard({
             )}
 
             {!isLoading && !error && chartData && (
-              <StockChart data={chartData} showVolume={true} height={280} />
+              <StockChart data={chartData} showVolume={false} height={200} />
             )}
 
             {!isLoading && !error && !chartData && !ticker && (
               <div className="flex h-full items-center justify-center">
-                <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                  Select a company to view price chart
+                <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                  Select a company
                 </p>
               </div>
             )}
           </div>
 
           {chartData && (
-            <div className="rounded-xl border p-3" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
+            <div className="rounded-xl border p-2" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
               <div className="flex items-center justify-between">
                 <div>
                   <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
                     Period Return
                   </span>
                   <p
-                    className="text-lg font-bold"
+                    className="text-base font-bold"
                     style={{
                       color: priceChange >= 0 ? "#10b981" : "#ef4444",
                     }}
@@ -243,9 +240,9 @@ export function MoatDashboard({
                 </div>
                 <div className="text-right">
                   <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
-                    Price Range
+                    Range
                   </span>
-                  <p className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
+                  <p className="text-xs font-semibold" style={{ color: "var(--text-primary)" }}>
                     ${Math.min(...chartData.low).toFixed(2)} - $
                     {Math.max(...chartData.high).toFixed(2)}
                   </p>
@@ -256,83 +253,81 @@ export function MoatDashboard({
         </div>
 
         {/* Moat Radar */}
-        <div
-          className="flex flex-col gap-4 rounded-xl border p-6"
-          style={{
-            borderColor: "var(--border)",
-            backgroundColor: "var(--background)",
-            minHeight: "300px",
-          }}
-        >
-          {/* Moat Rating Badge - only shown when we have a real assessment */}
-          {moatAssessment && (
-            <div className="flex items-center justify-between">
-              <div>
-                <span className="text-xs uppercase tracking-wider" style={{ color: "var(--text-tertiary)" }}>
-                  Moat Rating
-                </span>
-                <p className="mt-1 text-lg font-bold" style={{ 
-                  color: moatAssessment.overall_rating === "Wide" ? "#10b981" : 
-                         moatAssessment.overall_rating === "Narrow" ? "#eab308" : "#ef4444" 
-                }}>
-                  {moatAssessment.overall_rating} Moat
-                </p>
+        <div className="flex flex-col gap-3 flex-shrink-0">
+          <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-secondary)" }}>
+            Moat Analysis
+          </h3>
+          <div
+            className="flex flex-col gap-3 rounded-xl border p-4"
+            style={{
+              borderColor: "var(--border)",
+              backgroundColor: "var(--background)",
+            }}
+          >
+            {/* Moat Rating Badge - only shown when we have a real assessment */}
+            {moatAssessment && (
+              <div className="flex items-center justify-between rounded-lg border p-2" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
+                <div>
+                  <span className="text-xs uppercase tracking-wider" style={{ color: "var(--text-tertiary)" }}>
+                    Rating
+                  </span>
+                  <p className="mt-0.5 text-base font-bold" style={{ 
+                    color: moatAssessment.overall_rating === "Wide" ? "#10b981" : 
+                           moatAssessment.overall_rating === "Narrow" ? "#eab308" : "#ef4444" 
+                  }}>
+                    {moatAssessment.overall_rating} Moat
+                  </p>
+                </div>
+                <div className="text-right">
+                  <span className="text-xs uppercase tracking-wider" style={{ color: "var(--text-tertiary)" }}>
+                    Confidence
+                  </span>
+                  <p className="mt-0.5 text-xs font-semibold" style={{ color: "var(--text-secondary)" }}>
+                    {moatAssessment.overall_confidence}
+                  </p>
+                </div>
               </div>
-              <div className="text-right">
-                <span className="text-xs uppercase tracking-wider" style={{ color: "var(--text-tertiary)" }}>
-                  Confidence
-                </span>
-                <p className="mt-1 text-sm font-semibold" style={{ color: "var(--text-secondary)" }}>
-                  {moatAssessment.overall_confidence}
-                </p>
-              </div>
-            </div>
-          )}
+            )}
 
-          {ticker ? (
-            <div className="flex flex-col items-center gap-4">
-              <MoatRadar scores={moatScores} size={280} />
-              
-              {/* Hint when no assessment yet */}
-              {!moatAssessment && (
-                <p className="text-center text-xs" style={{ color: "var(--text-tertiary)" }}>
-                  Ask a question in the chat to analyze this company&apos;s moat
+            {ticker ? (
+              <div className="flex flex-col items-center gap-3">
+                <MoatRadar scores={moatScores} size={240} />
+                
+                {/* Hint when no assessment yet */}
+                {!moatAssessment && (
+                  <p className="text-center text-xs" style={{ color: "var(--text-tertiary)" }}>
+                    Ask about moat analysis in chat
+                  </p>
+                )}
+              </div>
+            ) : (
+              <div className="flex h-32 items-center justify-center">
+                <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+                  Select a company
                 </p>
-              )}
-            </div>
-          ) : (
-            <div className="flex h-full items-center justify-center">
-              <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
-                Select a company to view MOAT analysis
-              </p>
-            </div>
-          )}
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
       {/* AI Explanation */}
-      <div className="rounded-2xl border p-5" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
-        <h3 className="text-xs font-semibold uppercase tracking-[0.3em]" style={{ color: "var(--text-secondary)" }}>
-          Price Movement Summary
-        </h3>
-        <p className="mt-3 text-sm leading-relaxed" style={{ color: "var(--text-primary)" }}>
-          {chartData ? (
-            <>
-              {ticker} {priceChange >= 0 ? "gained" : "declined"}{" "}
-              <span className="font-semibold" style={{ color: priceChange >= 0 ? "#10b981" : "#ef4444" }}>
-                {Math.abs(priceChange).toFixed(2)}%
-              </span>{" "}
-              from {new Date(chartData.start_date).toLocaleDateString()} to{" "}
-              {new Date(chartData.end_date).toLocaleDateString()}, moving from $
-              {chartData.close[0].toFixed(2)} to ${chartData.close[chartData.close.length - 1].toFixed(2)}.
-              The stock reached a high of ${Math.max(...chartData.high).toFixed(2)} and a low of $
-              {Math.min(...chartData.low).toFixed(2)} during this period.
-            </>
-          ) : (
-            "Select a company and date range to view price movement analysis."
-          )}
-        </p>
-      </div>
+      {chartData && (
+        <div className="rounded-xl border p-3 flex-shrink-0" style={{ borderColor: "var(--border)", backgroundColor: "var(--border-subtle)" }}>
+          <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: "var(--text-secondary)" }}>
+            Summary
+          </h3>
+          <p className="mt-2 text-xs leading-relaxed" style={{ color: "var(--text-primary)" }}>
+            {ticker} {priceChange >= 0 ? "gained" : "declined"}{" "}
+            <span className="font-semibold" style={{ color: priceChange >= 0 ? "#10b981" : "#ef4444" }}>
+              {Math.abs(priceChange).toFixed(2)}%
+            </span>{" "}
+            from {new Date(chartData.start_date).toLocaleDateString()} to{" "}
+            {new Date(chartData.end_date).toLocaleDateString()}, moving from $
+            {chartData.close[0].toFixed(2)} to ${chartData.close[chartData.close.length - 1].toFixed(2)}.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,11 @@
+export { ActiveShell } from "./ActiveShell";
+export { CompanyCard } from "./CompanyCard";
+export { CompanySelector } from "./CompanySelector";
+export { CompanySelectorCompact } from "./CompanySelectorCompact";
+export { DateRangePicker } from "./DateRangePicker";
+export { DateRangePickerCompact } from "./DateRangePickerCompact";
+export { ExamplePrompts } from "./ExamplePrompts";
+export { Logo } from "./Logo";
+export { ThemeToggle } from "./ThemeToggle";
+export { ThreeColumnLayout } from "./ThreeColumnLayout";
+export { WelcomeScreen } from "./WelcomeScreen";

--- a/frontend/src/components/studio/StudioCard.tsx
+++ b/frontend/src/components/studio/StudioCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+
+type StudioCardProps = {
+  id: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  available: boolean;
+  onClick: () => void;
+  isExpanded: boolean;
+  isLoading?: boolean;
+};
+
+export function StudioCard({
+  title,
+  description,
+  icon,
+  available,
+  onClick,
+  isExpanded,
+  isLoading,
+}: StudioCardProps) {
+  const [isHovered, setIsHovered] = useState(false);
+
+  return (
+    <button
+      onClick={onClick}
+      disabled={!available}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      className="w-full text-left transition-all duration-200"
+      style={{
+        opacity: available ? 1 : 0.5,
+        cursor: available ? "pointer" : "not-allowed",
+      }}
+    >
+      <div
+        className="rounded-xl border p-4 transition-all"
+        style={{
+          borderColor: isExpanded
+            ? "var(--accent)"
+            : isHovered && available
+            ? "var(--accent)"
+            : "var(--border)",
+          backgroundColor: isExpanded
+            ? "color-mix(in srgb, var(--accent) 10%, transparent)"
+            : isHovered && available
+            ? "color-mix(in srgb, var(--surface) 50%, transparent)"
+            : "var(--background)",
+          transform: isHovered && available ? "translateY(-2px)" : "none",
+        }}
+      >
+        <div className="flex items-start gap-3">
+          {/* Icon */}
+          <div
+            className="flex-shrink-0 mt-0.5"
+            style={{
+              color: isExpanded ? "var(--accent)" : "var(--text-secondary)",
+            }}
+          >
+            {icon}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-1">
+              <h4
+                className="text-sm font-semibold"
+                style={{ color: "var(--text-primary)" }}
+              >
+                {title}
+              </h4>
+              {isLoading && (
+                <div
+                  className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-solid border-current border-r-transparent"
+                  style={{ color: "var(--accent)" }}
+                />
+              )}
+            </div>
+            <p
+              className="text-xs leading-relaxed"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {description}
+            </p>
+            {!available && (
+              <p
+                className="text-xs mt-1 italic"
+                style={{ color: "var(--text-tertiary)" }}
+              >
+                Select a company in Sources to enable
+              </p>
+            )}
+          </div>
+
+          {/* Expand indicator */}
+          {available && (
+            <div
+              className="flex-shrink-0"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className={`transition-transform ${isExpanded ? "rotate-180" : ""}`}
+              >
+                <path d="M19 9l-7 7-7-7" />
+              </svg>
+            </div>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/components/studio/StudioCardExpanded.tsx
+++ b/frontend/src/components/studio/StudioCardExpanded.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+type StudioCardExpandedProps = {
+  children: React.ReactNode;
+  onCollapse: () => void;
+};
+
+export function StudioCardExpanded({ children, onCollapse }: StudioCardExpandedProps) {
+  return (
+    <div
+      className="rounded-xl border p-4 mb-4 animate-in fade-in slide-in-from-top-2 duration-300"
+      style={{
+        borderColor: "var(--border)",
+        backgroundColor: "var(--background)",
+      }}
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h4
+          className="text-xs uppercase tracking-wider font-semibold"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          Visualization
+        </h4>
+        <button
+          onClick={onCollapse}
+          className="p-1 rounded-lg hover:bg-opacity-20 transition-all"
+          style={{ color: "var(--text-secondary)" }}
+          title="Collapse"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M18 15l-6-6-6 6" />
+          </svg>
+        </button>
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/studio/index.ts
+++ b/frontend/src/components/studio/index.ts
@@ -1,0 +1,2 @@
+export { StudioCard } from "./StudioCard";
+export { StudioCardExpanded } from "./StudioCardExpanded";

--- a/frontend/src/components/studio/views/MoatRadarView.tsx
+++ b/frontend/src/components/studio/views/MoatRadarView.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { MoatRadar, type MoatScores } from "@/components/charts";
+import { type MoatAssessment } from "@/lib/moatTutorApi";
+
+type MoatRadarViewProps = {
+  moatAssessment?: MoatAssessment | null;
+};
+
+export function MoatRadarView({ moatAssessment }: MoatRadarViewProps) {
+  if (!moatAssessment) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+          No moat assessment available. Ask a question in chat to generate an analysis.
+        </p>
+      </div>
+    );
+  }
+
+  const moatScores: MoatScores = {
+    networkEffects: moatAssessment.network_effects.score,
+    switchingCosts: moatAssessment.switching_costs.score,
+    intangibleAssets: moatAssessment.intangible_assets.score,
+    costAdvantages: moatAssessment.cost_advantages.score,
+    efficientScale: moatAssessment.regulatory_barriers.score,
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Moat Rating Badge */}
+      <div
+        className="rounded-lg border p-3"
+        style={{
+          borderColor: "var(--border)",
+          backgroundColor: "var(--border-subtle)",
+        }}
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <span
+              className="text-xs uppercase tracking-wider"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              Rating
+            </span>
+            <p
+              className="text-lg font-bold mt-1"
+              style={{
+                color:
+                  moatAssessment.overall_rating === "Wide"
+                    ? "#10b981"
+                    : moatAssessment.overall_rating === "Narrow"
+                    ? "#eab308"
+                    : "#ef4444",
+              }}
+            >
+              {moatAssessment.overall_rating} Moat
+            </p>
+          </div>
+          <div className="text-right">
+            <span
+              className="text-xs uppercase tracking-wider"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              Confidence
+            </span>
+            <p
+              className="text-sm font-semibold mt-1"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              {moatAssessment.overall_confidence}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Radar Chart */}
+      <div className="flex justify-center py-4">
+        <MoatRadar scores={moatScores} size={280} />
+      </div>
+
+      {/* Assessment Period */}
+      <div className="text-center">
+        <p className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+          Assessment Period: {moatAssessment.assessment_period}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/studio/views/OverallMoatView.tsx
+++ b/frontend/src/components/studio/views/OverallMoatView.tsx
@@ -4,18 +4,22 @@ import { useState, useEffect } from "react";
 import { getOverallMoatScore, type OverallMoatScore } from "@/lib/moatTutorApi";
 import { MoatRadar, type MoatScores } from "@/components/charts";
 
+/** Fixed analysis period for overall moat rating (not user-selected). */
+const MOAT_ANALYSIS_START = "2015-01-01";
+const MOAT_ANALYSIS_END = "2025-12-31";
+
 type OverallMoatViewProps = {
   ticker?: string | null;
+  /** Not used for API; kept for prop compatibility. Moat rating is always 2015-2025. */
   startDate?: string | null;
+  /** Not used for API; kept for prop compatibility. Moat rating is always 2015-2025. */
   endDate?: string | null;
-  useFullRange?: boolean; // True if user selected 2015-2025
+  /** Not used; moat rating always uses full range 2015-2025. */
+  useFullRange?: boolean;
 };
 
 export function OverallMoatView({
   ticker,
-  startDate,
-  endDate,
-  useFullRange,
 }: OverallMoatViewProps) {
   const [moatScore, setMoatScore] = useState<OverallMoatScore | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -32,12 +36,11 @@ export function OverallMoatView({
       setError(null);
 
       try {
-        // If user has selected full range (2015-2025), use cached analysis
-        // Otherwise, compute from scratch with their selected dates
+        // Always request full 2015-2025 range; moat rating is defined for this period only.
         const data = await getOverallMoatScore({
           ticker,
-          startDate: useFullRange ? "2015-01-01" : startDate || undefined,
-          endDate: useFullRange ? "2025-12-31" : endDate || undefined,
+          startDate: MOAT_ANALYSIS_START,
+          endDate: MOAT_ANALYSIS_END,
         });
         setMoatScore(data);
       } catch (err) {
@@ -49,7 +52,7 @@ export function OverallMoatView({
     };
 
     loadMoatScore();
-  }, [ticker, startDate, endDate, useFullRange]);
+  }, [ticker]);
 
   if (isLoading) {
     return (
@@ -60,12 +63,10 @@ export function OverallMoatView({
             style={{ color: "var(--accent)" }}
           />
           <p className="text-sm font-semibold mb-1" style={{ color: "var(--text-primary)" }}>
-            {useFullRange ? "Loading Full Analysis" : "Computing Analysis"}
+            Loading Full Analysis
           </p>
           <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
-            {useFullRange
-              ? "Retrieving cached 2015-2025 moat analysis..."
-              : "Analyzing moat characteristics for selected period..."}
+            Retrieving 2015-2025 moat analysis...
           </p>
         </div>
       </div>
@@ -219,7 +220,7 @@ export function OverallMoatView({
       </div>
 
       {/* Performance Optimization Note */}
-      {useFullRange && (
+      {(
         <div
           className="rounded-lg border p-3 text-xs"
           style={{

--- a/frontend/src/components/studio/views/OverallMoatView.tsx
+++ b/frontend/src/components/studio/views/OverallMoatView.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getOverallMoatScore, type OverallMoatScore } from "@/lib/moatTutorApi";
+import { MoatRadar, type MoatScores } from "@/components/charts";
+
+type OverallMoatViewProps = {
+  ticker?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  useFullRange?: boolean; // True if user selected 2015-2025
+};
+
+export function OverallMoatView({
+  ticker,
+  startDate,
+  endDate,
+  useFullRange,
+}: OverallMoatViewProps) {
+  const [moatScore, setMoatScore] = useState<OverallMoatScore | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadMoatScore = async () => {
+      if (!ticker) {
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        // If user has selected full range (2015-2025), use cached analysis
+        // Otherwise, compute from scratch with their selected dates
+        const data = await getOverallMoatScore({
+          ticker,
+          startDate: useFullRange ? "2015-01-01" : startDate || undefined,
+          endDate: useFullRange ? "2025-12-31" : endDate || undefined,
+        });
+        setMoatScore(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load moat score");
+        console.error("Overall moat score error:", err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadMoatScore();
+  }, [ticker, startDate, endDate, useFullRange]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <div className="text-center">
+          <div
+            className="mb-3 inline-block h-10 w-10 animate-spin rounded-full border-4 border-solid border-current border-r-transparent"
+            style={{ color: "var(--accent)" }}
+          />
+          <p className="text-sm font-semibold mb-1" style={{ color: "var(--text-primary)" }}>
+            {useFullRange ? "Loading Full Analysis" : "Computing Analysis"}
+          </p>
+          <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+            {useFullRange
+              ? "Retrieving cached 2015-2025 moat analysis..."
+              : "Analyzing moat characteristics for selected period..."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <p className="text-sm font-semibold mb-2" style={{ color: "var(--risk)" }}>
+            Error loading moat score
+          </p>
+          <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+            {error}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!moatScore) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+          No moat score available
+        </p>
+      </div>
+    );
+  }
+
+  const moatScores: MoatScores = {
+    networkEffects: moatScore.factors.network_effects,
+    switchingCosts: moatScore.factors.switching_costs,
+    intangibleAssets: moatScore.factors.intangible_assets,
+    costAdvantages: moatScore.factors.cost_advantages,
+    efficientScale: moatScore.factors.regulatory_barriers,
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Header Info */}
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--border)",
+          backgroundColor: "var(--border-subtle)",
+        }}
+      >
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            <span
+              className="text-xs uppercase tracking-wider"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              Overall Moat Rating
+            </span>
+            <p
+              className="text-2xl font-bold mt-1"
+              style={{
+                color:
+                  moatScore.rating === "Wide"
+                    ? "#10b981"
+                    : moatScore.rating === "Narrow"
+                    ? "#eab308"
+                    : "#ef4444",
+              }}
+            >
+              {moatScore.rating} Moat
+            </p>
+            <p className="text-sm mt-1" style={{ color: "var(--text-secondary)" }}>
+              Score: {moatScore.overall_score.toFixed(2)} / 5.0
+            </p>
+          </div>
+          <div className="text-right">
+            <span
+              className="text-xs uppercase tracking-wider"
+              style={{ color: "var(--text-tertiary)" }}
+            >
+              Trend
+            </span>
+            <p
+              className="text-sm font-semibold mt-1"
+              style={{
+                color:
+                  moatScore.trend === "strengthening"
+                    ? "#10b981"
+                    : moatScore.trend === "weakening"
+                    ? "#ef4444"
+                    : "var(--text-secondary)",
+              }}
+            >
+              {moatScore.trend === "strengthening" && "↗ Strengthening"}
+              {moatScore.trend === "stable" && "→ Stable"}
+              {moatScore.trend === "weakening" && "↘ Weakening"}
+            </p>
+          </div>
+        </div>
+
+        <div className="pt-3 border-t" style={{ borderColor: "var(--border)" }}>
+          <div className="flex items-center justify-between text-xs">
+            <span style={{ color: "var(--text-tertiary)" }}>
+              Analysis Period: {moatScore.time_range}
+            </span>
+            <span style={{ color: "var(--text-tertiary)" }}>
+              Confidence: {moatScore.confidence}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Radar Chart */}
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--border)",
+          backgroundColor: "var(--background)",
+        }}
+      >
+        <h4
+          className="text-xs uppercase tracking-wider font-semibold mb-4"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          Moat Factor Breakdown
+        </h4>
+        <div className="flex justify-center">
+          <MoatRadar scores={moatScores} size={300} />
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div
+        className="rounded-lg border p-4"
+        style={{
+          borderColor: "var(--border)",
+          backgroundColor: "var(--surface)",
+        }}
+      >
+        <h4
+          className="text-xs uppercase tracking-wider font-semibold mb-2"
+          style={{ color: "var(--text-secondary)" }}
+        >
+          Summary
+        </h4>
+        <p
+          className="text-sm leading-relaxed"
+          style={{ color: "var(--text-primary)" }}
+        >
+          {moatScore.summary}
+        </p>
+      </div>
+
+      {/* Performance Optimization Note */}
+      {useFullRange && (
+        <div
+          className="rounded-lg border p-3 text-xs"
+          style={{
+            borderColor: "color-mix(in srgb, var(--accent) 30%, transparent)",
+            backgroundColor: "color-mix(in srgb, var(--accent) 5%, transparent)",
+            color: "var(--text-secondary)",
+          }}
+        >
+          <div className="flex items-start gap-2">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              className="flex-shrink-0 mt-0.5"
+              style={{ color: "var(--accent)" }}
+            >
+              <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" />
+            </svg>
+            <p>
+              <strong style={{ color: "var(--accent)" }}>Optimized:</strong> Using
+              cached full-range analysis for maximum performance.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/studio/views/PriceChartView.tsx
+++ b/frontend/src/components/studio/views/PriceChartView.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { StockChart } from "@/components/charts";
+import { getChartData, type ChartDataResponse } from "@/lib/moatTutorApi";
+
+type PriceChartViewProps = {
+  ticker?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+};
+
+export function PriceChartView({ ticker, startDate, endDate }: PriceChartViewProps) {
+  const [chartData, setChartData] = useState<ChartDataResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadChartData = async () => {
+      if (!ticker) {
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const data = await getChartData({
+          ticker,
+          startDate,
+          endDate,
+          interval: "auto",
+        });
+        setChartData(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load chart data");
+        console.error("Chart data error:", err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadChartData();
+  }, [ticker, startDate, endDate]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <div
+            className="mb-3 inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-current border-r-transparent"
+            style={{ color: "var(--accent)" }}
+          />
+          <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+            Loading chart data...
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <p className="text-sm font-semibold mb-2" style={{ color: "var(--risk)" }}>
+            Error loading chart
+          </p>
+          <p className="text-xs" style={{ color: "var(--text-secondary)" }}>
+            {error}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!chartData) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <p className="text-sm" style={{ color: "var(--text-secondary)" }}>
+          No chart data available
+        </p>
+      </div>
+    );
+  }
+
+  const priceChange =
+    ((chartData.close[chartData.close.length - 1] - chartData.close[0]) /
+      chartData.close[0]) *
+    100;
+
+  return (
+    <div className="space-y-4">
+      <div
+        className="rounded-lg border p-3"
+        style={{
+          borderColor: "var(--border)",
+          backgroundColor: "var(--surface)",
+        }}
+      >
+        <StockChart data={chartData} showVolume={true} height={300} />
+      </div>
+
+      <div
+        className="rounded-lg border p-3"
+        style={{
+          borderColor: "var(--border)",
+          backgroundColor: "var(--border-subtle)",
+        }}
+      >
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+              Period Return
+            </span>
+            <p
+              className="text-lg font-bold mt-1"
+              style={{
+                color: priceChange >= 0 ? "#10b981" : "#ef4444",
+              }}
+            >
+              {priceChange >= 0 ? "▲" : "▼"} {Math.abs(priceChange).toFixed(2)}%
+            </p>
+          </div>
+          <div>
+            <span className="text-xs" style={{ color: "var(--text-tertiary)" }}>
+              Price Range
+            </span>
+            <p className="text-sm font-semibold mt-1" style={{ color: "var(--text-primary)" }}>
+              ${Math.min(...chartData.low).toFixed(2)} - $
+              {Math.max(...chartData.high).toFixed(2)}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/studio/views/index.ts
+++ b/frontend/src/components/studio/views/index.ts
@@ -1,0 +1,3 @@
+export { PriceChartView } from "./PriceChartView";
+export { MoatRadarView } from "./MoatRadarView";
+export { OverallMoatView } from "./OverallMoatView";

--- a/frontend/src/lib/moatTutorApi.ts
+++ b/frontend/src/lib/moatTutorApi.ts
@@ -491,3 +491,49 @@ export async function analyzeComprehensive(params: {
   }
 }
 
+// ============================================================================
+// Overall Moat Score API (2015-2025 Full Analysis)
+// ============================================================================
+
+export type OverallMoatScore = {
+  overall_score: number; // 0-5 scale
+  rating: "Wide" | "Narrow" | "None";
+  confidence: string;
+  time_range: string;
+  computed_at: string;
+  factors: {
+    network_effects: number;
+    switching_costs: number;
+    intangible_assets: number;
+    cost_advantages: number;
+    regulatory_barriers: number;
+  };
+  trend: "strengthening" | "stable" | "weakening";
+  summary: string;
+};
+
+export async function getOverallMoatScore(params: {
+  ticker: string;
+  startDate?: string;
+  endDate?: string;
+  signal?: AbortSignal;
+}): Promise<OverallMoatScore> {
+  try {
+    const { ticker, startDate, endDate } = params;
+    
+    // Build query params
+    const queryParams = new URLSearchParams({ ticker });
+    if (startDate) queryParams.append("start_date", startDate);
+    if (endDate) queryParams.append("end_date", endDate);
+    
+    return await fetchJson<OverallMoatScore>(
+      `/api/v1/moat/overall?${queryParams.toString()}`,
+      {
+        method: "GET",
+        signal: params.signal,
+      }
+    );
+  } catch (error) {
+    throw new Error(`Failed to fetch overall moat score: ${toErrorMessage(error)}`);
+  }
+}


### PR DESCRIPTION
## Summary of Changes

This branch brings in the refined frontend design and the backend work that supports it: three-column layout with studio dashboard, theme support, company/date selection, chat with streaming, and data-driven overall moat scores. It is the single merge that moves from the initial scaffold to the current app.

## What this branch changes

- **Frontend**
  - Three-column layout (chat | controls | studio), welcome screen, active shell.
  - Studio: price chart, moat radar, **overall moat view** (fixed 2015–2025 period).
  - Charts (recharts), MoatDashboard/WindowedMoatDashboard, chat components, API client..

- **Backend**
  - **Overall moat**: `GET /api/v1/moat/overall?ticker=...` uses real data (price + optional FNSPID); fixed 2015–2025; per-ticker cache.
  - **Config**: `OPENAI_API_KEY` required only when `LLM_PROVIDER=openai`; optional for `LLM_PROVIDER=local` (Ollama). Audio route returns 503 with a clear message when the key is missing.
  - API routes (health, chat, analysis, audio, companies, charts, windowed moat, moat overall), agent + tools, services (stock_data, yfinance, FNSPID, data_driven_moat_scorer, etc.), and `env.example`.